### PR TITLE
fixed codecov badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Python](https://img.shields.io/badge/Language-Python-blue.svg)](https://python.org/)
 [![CI](https://github.com/CSCI-GA-2820-SP25-003/inventory/actions/workflows/ci.yml/badge.svg)](https://github.com/CSCI-GA-2820-SP25-003/inventory/actions)
-[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP25-003/inventory/branch/main/graph/badge.svg)](https://codecov.io/gh/CSCI-GA-2820-SP25-003/inventory)
+[![codecov](https://codecov.io/gh/CSCI-GA-2820-SP25-003/inventory/graph/badge.svg?token=SJIJ642XDQ)](https://codecov.io/gh/CSCI-GA-2820-SP25-003/inventory)
 
 ## Manual Setup
 


### PR DESCRIPTION
Fixed the codecov badge in readme so that the codecov badge correctly displays the coverage percentage on github